### PR TITLE
Remove Magnify Mobile

### DIFF
--- a/src/scripts/vendor.js
+++ b/src/scripts/vendor.js
@@ -6,7 +6,6 @@
 // =require ../../node_modules/jquery/dist/jquery.min.js
 
 // =require ../../node_modules/magnify/dist/js/jquery.magnify.js
-// =require ../../node_modules/magnify/dist/js/jquery.magnify-mobile.js
 
 // =require ../../node_modules/accessible-mega-menu/js/jquery-accessibleMegaMenu.js
 


### PR DESCRIPTION
There is an issue with the Mobile plugin, in that it breaks window.resize() callbacks.