### PR TITLE
Remove GTM code

### DIFF
--- a/src/config/settings_schema.json
+++ b/src/config/settings_schema.json
@@ -8,16 +8,6 @@
     "theme_support_email": "mulleyjb@parliament.uk"
   },
   {
-    "name": "GTM Code",
-    "settings": [
-      {
-        "type": "text",
-        "id": "gtm_code",
-        "label": "GTM Code"
-      }
-    ]
-  },
-  {
     "name": "Typography",
     "settings": [
       {

--- a/src/layout/theme.liquid
+++ b/src/layout/theme.liquid
@@ -57,26 +57,9 @@
   <!--[if lt IE 9]><script src="{{ 'theme.js' | asset_url }}"></script><![endif]-->
 
   {{ content_for_header }}
-
-  {% if settings.gtm_code %}
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','{{ settings.gtm_code }}');</script>
-    <!-- End Google Tag Manager -->
-  {% endif %}
 </head>
 
 <body id="{{ page_title | handle }}" class="sticky-footer template-{{ template.name | handle }}">
-
-  {% if settings.gtm_code %}
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ settings.gtm_code }}"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
-  {% endif %}
 
   <a class="in-page-link visually-hidden skip-link" href="#MainContent">{{ 'general.accessibility.skip_to_content' | t }}</a>
 


### PR DESCRIPTION
The GTM code is no longer used in favour of Shopify's built-in Analytics setup.